### PR TITLE
Make usable as `cmap` in MPL

### DIFF
--- a/complex_colormap/cplot.py
+++ b/complex_colormap/cplot.py
@@ -307,12 +307,27 @@ def const_chroma_colormap_mpl(N):
     """Makes colormap of size `N`, passable to `plt.imshow(cmap=)`.
     Retrieve 3D array values via `.colors`.
     """
-    N = 1024
-    J = ((1.0 - (1 / (1.0 + np.ones(N)**0.3))) * 100)[None]
+    J = (1.0 - (1 / (1.0 + np.ones((1, N))**0.3))) * 100
     h = np.linspace(-180, 180, N)[None]
     C = const_interpolator(J)
     JCh = np.stack((J, C, h), axis=-1)
     rgb = cspace_convert(JCh, new_space, 'sRGB1')[0]
+    rgb = rgb.clip(0, 1)
+
+    cm = ListedColormap(rgb)
+    return cm
+
+
+def max_chroma_colormap_mpl(N):
+    """Makes colormap of size `N`, passable to `plt.imshow(cmap=)`.
+    Retrieve 3D array values via `.colors`.
+    """
+    # Map magnitude in [0, ∞] to J in [0, 100]
+    J = (1.0 - (1 / (1.0 + np.ones((1, N))**0.3))) * 100
+    h = np.linspace(-180, 180, N)[None]
+    C = max_interpolator(J, h, grid=False)
+    JCh = np.stack((J, C, h), axis=-1)
+    rgb = cspace_convert(JCh, new_space, "sRGB1")[0]
     rgb = rgb.clip(0, 1)
 
     cm = ListedColormap(rgb)

--- a/complex_colormap/cplot.py
+++ b/complex_colormap/cplot.py
@@ -13,7 +13,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.image
 from scipy.interpolate import interp1d, RectBivariateSpline
-from matplotlib.colors import colorConverter
+from matplotlib.colors import colorConverter, ListedColormap
 from colorspacious import cspace_convert
 import numbers
 import os
@@ -301,6 +301,22 @@ def cplot(f, re=(-5, 5), im=(-5, 5), points=160000, color='const', file=None,
             plt.show()
 
     return axes
+
+
+def const_chroma_colormap_mpl(N):
+    """Makes colormap of size `N`, passable to `plt.imshow(cmap=)`.
+    Retrieve 3D array values via `.colors`.
+    """
+    N = 1024
+    J = ((1.0 - (1 / (1.0 + np.ones(N)**0.3))) * 100)[None]
+    h = np.linspace(-180, 180, N)[None]
+    C = const_interpolator(J)
+    JCh = np.stack((J, C, h), axis=-1)
+    rgb = cspace_convert(JCh, new_space, 'sRGB1')[0]
+    rgb = rgb.clip(0, 1)
+
+    cm = ListedColormap(rgb)
+    return cm
 
 
 if __name__ == '__main__':

--- a/examples/matplotlib_simple.py
+++ b/examples/matplotlib_simple.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+import matplotlib.pyplot as plt
+from complex_colormap.cplot import const_chroma_colormap_mpl
+
+# size
+N = 512
+# frequency
+f = 1
+# whether to use amplitude modulation (bool)
+AM = 0
+
+# make sine
+t = np.arange(N)/N
+x = np.cos(2*np.pi*f*t) + 1j*np.sin(2*np.pi*f*t)
+x = np.repeat(x[None], N, 0)
+if AM:
+    x *= t[::-1]
+
+# plot
+cm = const_chroma_colormap_mpl(N)
+plt.imshow(np.angle(x), alpha=np.abs(x)**(1/2), cmap=cm,
+           interpolation='nearest', aspect='auto')
+# (other interpolations tend to produce artifacts per phase jump)


### PR DESCRIPTION
Allows custom handling of magnitude via `alpha`, and general colormap use. 

Also added minimal example illustrating - here's with and without linear A.M.:

<img src="https://github.com/endolith/complex_colormap/assets/16495490/06e46762-bd27-41e1-a781-dc3536b77c49" width="700">



